### PR TITLE
Bowling score calculator

### DIFF
--- a/BowlingKata.Tests/BowlingKata.Tests.csproj
+++ b/BowlingKata.Tests/BowlingKata.Tests.csproj
@@ -43,7 +43,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BowlingTests.cs" />
+    <Compile Include="FrameTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RollSeriesTests.cs" />
+    <Compile Include="RollTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/BowlingKata.Tests/BowlingKata.Tests.csproj
+++ b/BowlingKata.Tests/BowlingKata.Tests.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4F2877A9-BE06-4AAD-8A3B-0898D7C2CFB0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BowlingKata.Tests</RootNamespace>
+    <AssemblyName>BowlingKata.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BowlingKata\BowlingKata.csproj">
+      <Project>{dedc4e5d-7c35-4b99-8e8a-89f5b3d40dbd}</Project>
+      <Name>BowlingKata</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BowlingKata.Tests/BowlingTests.cs
+++ b/BowlingKata.Tests/BowlingTests.cs
@@ -1,0 +1,50 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata.Tests
+{
+    [TestFixture]
+    public class BowlingTests
+    {
+        private Bowling _game;
+
+        [SetUp]
+        public void Setup()
+        {
+            _game = new Bowling();
+        }
+
+        [Test]
+        public void CalculateScore_GivenGutterBallGame_ReturnsScore0()
+        {
+            Assert.AreEqual(0, _game.CalculateScore("--------------------"));
+        }
+
+        [Test]
+        public void CalculateScore_GivenPerfectGame_ReturnsScore300()
+        {
+            Assert.AreEqual(300, _game.CalculateScore("XXXXXXXXXXXX"));
+        }
+
+        [TestCase("819-7263458163369-9-", 90)]
+        [TestCase("7---34--51-871528/9-", 71)]
+        [TestCase("-/-/9/X547-6-8-819/X", 127)]
+        [TestCase("XX9/XX7/XX2/XX5", 223)]
+        public void CalculateScore_GivenCompletedGames_ReturnsScoreOfGame(string rolls, int expectedScore)
+        {
+            Assert.AreEqual(expectedScore, _game.CalculateScore(rolls));
+        }
+
+        [TestCase("-/-/-/-/-/-/-/-/-/-/-", 100)]
+        [TestCase("-/1/2/3/4/5/6/7/8/9/5", 150)]
+        [TestCase("9/9/9/9/9/9/9/9/9/9/9", 190)]
+        public void CalculateScore_GivenFramesClosedBySpares_ReturnsScoreOfGame(string rolls, int expectedScore)
+        {
+            Assert.AreEqual(expectedScore, _game.CalculateScore(rolls));
+        }
+    }
+}

--- a/BowlingKata.Tests/FrameTests.cs
+++ b/BowlingKata.Tests/FrameTests.cs
@@ -1,0 +1,75 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata.Tests
+{
+    [TestFixture]
+    class FrameTests
+    {
+        [Test]
+        public void GetFrameLength_GivenOpenFrame_ReturnsLength2()
+        {
+            Assert.AreEqual(2, Frame.GetFrameLength("9/"));
+        }
+
+        [Test]
+        public void GetFrameLength_GivenSpare_ReturnsLength2()
+        {
+            Assert.AreEqual(2, Frame.GetFrameLength("9/"));
+        }
+
+        [Test]
+        public void GetFrameLength_GivenStrike_ReturnsLength1()
+        {
+            Assert.AreEqual(1, Frame.GetFrameLength("X"));
+        }
+
+        [TestCase("81")]
+        [TestCase("51")]
+        [TestCase("62")]
+        public void HasMultiFrameScore_GivenOpenFrames_ReturnsFalse(string frame)
+        {
+            Assert.IsFalse(Frame.HasMultiFrameScore(frame));
+        }
+
+        [Test]
+        public void HasMultiFrameScore_GivenStrike_ReturnsTrue()
+        {
+            Assert.IsTrue(Frame.HasMultiFrameScore("X"));
+        }
+
+        [Test]
+        public void HasMultiFrameScore_GivenSpare_ReturnsTrue()
+        {
+            Assert.IsTrue(Frame.HasMultiFrameScore("8/"));
+        }
+
+        [Test]
+        public void HasSpare_GivenClosedFrame_ReturnsTrue()
+        {
+            Assert.IsTrue(Frame.HasSpare("9/"));
+        }
+
+        [Test]
+        public void HasSpare_GivenOpenFrame_ReturnsFalse()
+        {
+            Assert.IsFalse(Frame.HasSpare("9-"));
+        }
+
+        [Test]
+        public void HasStrike_GivenStrike_ReturnsTrue()
+        {
+            Assert.IsTrue(Frame.HasStrike("X"));
+        }
+
+        [Test]
+        public void HasStrike_GivenOpenFrame_ReturnsFalse()
+        {
+            Assert.IsFalse(Frame.HasStrike("--"));
+        }
+    }
+}

--- a/BowlingKata.Tests/Properties/AssemblyInfo.cs
+++ b/BowlingKata.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BowlingKata.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BowlingKata.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4f2877a9-be06-4aad-8a3b-0898d7c2cfb0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BowlingKata.Tests/RollSeriesTests.cs
+++ b/BowlingKata.Tests/RollSeriesTests.cs
@@ -1,0 +1,77 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata.Tests
+{
+    [TestFixture]
+    public class RollSeriesTests
+    {
+        [Test]
+        public void GetFirstFrameLength_GivenGutterBalls_ReturnsLength2()
+        {
+            var rollSeries = new RollSeries("--");
+            Assert.AreEqual(2, rollSeries.GetFirstFrameLength());
+        }
+
+        [TestCase("9-")]
+        [TestCase("815-")]
+        [TestCase("234561")]
+        public void GetFirstFrameLength_GivenOpenFramesWithVaryingNumberOfRolls_ReturnsLength2(string rolls)
+        {
+            var rollSeries = new RollSeries(rolls);
+            Assert.AreEqual(2, rollSeries.GetFirstFrameLength());
+        }
+
+        [Test]
+        public void GetFirstFrameLength_GivenSpare_ReturnsLength2()
+        {
+            var rollSeries = new RollSeries("9/");
+            Assert.AreEqual(2, rollSeries.GetFirstFrameLength());
+        }
+
+        [Test]
+        public void GetFirstFrameLength_GivenStike_ReturnsLength1()
+        {
+            var rollSeries = new RollSeries("X");
+            Assert.AreEqual(1, rollSeries.GetFirstFrameLength());
+        }
+
+        [TestCase("X-")]
+        [TestCase("8/")]
+        [TestCase("7")]
+        public void GetFirstFrameScore_GivenIncompleteScore_ReturnsScore0(string rolls)
+        {
+            var rollSeries = new RollSeries(rolls);
+            Assert.AreEqual(0, rollSeries.GetFirstFrameScore());
+        }
+
+        [TestCase("9-", 9)]
+        [TestCase("815-", 9)]
+        [TestCase("234561", 5)]
+        public void GetFirstFrameScore_GivenOpenFramesWithVaryingNumberOfRolls_ReturnsScoreOfFirstTwoRolls(string rolls, int expectedValue)
+        {
+            var rollSeries = new RollSeries(rolls);
+            Assert.AreEqual(expectedValue, rollSeries.GetFirstFrameScore());
+        }
+
+        [TestCase("9/-", 10)]
+        [TestCase("7/3", 13)]
+        [TestCase("5/9", 19)]
+        public void GetFirstFrameScore_GivenSpare_ReturnsScore10PlusNexRoll(string rolls, int expectedValue)
+        {
+            var rollSeries = new RollSeries(rolls);
+            Assert.AreEqual(expectedValue, rollSeries.GetFirstFrameScore());
+        }
+
+        [Test]
+        public void GetFirstFrameScore_GivenTurkey_ReturnsScore30()
+        {
+            var rollSeries = new RollSeries("XXX");
+            Assert.AreEqual(30, rollSeries.GetFirstFrameScore());
+        }
+    }
+}

--- a/BowlingKata.Tests/RollTests.cs
+++ b/BowlingKata.Tests/RollTests.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata.Tests
+{
+    [TestFixture]
+    public class RollTests
+    {
+        [TestCase('2', 2)]
+        [TestCase('5', 5)]
+        [TestCase('9', 9)]
+        public void GetScoreOfRoll_GivenNumberOfPins_ReturnsScore(char score, int expectedValue)
+        {
+            Assert.AreEqual(expectedValue, Roll.GetScoreOfRoll(score));
+        }
+
+        [Test]
+        public void GetScoreOfRoll_GivenGutter_ReturnsScore0()
+        {
+            Assert.AreEqual(0, Roll.GetScoreOfRoll('-'));
+        }
+
+        [Test]
+        public void GetScoreOfRoll_GivenStrike_ReturnsScore10()
+        {
+            Assert.AreEqual(10, Roll.GetScoreOfRoll('X'));
+        }
+    }
+}

--- a/BowlingKata.Tests/packages.config
+++ b/BowlingKata.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.1" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net461" />
+</packages>

--- a/BowlingKata.sln
+++ b/BowlingKata.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BowlingKata", "BowlingKata\BowlingKata.csproj", "{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/BowlingKata.sln
+++ b/BowlingKata.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BowlingKata", "BowlingKata\BowlingKata.csproj", "{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BowlingKata.Tests", "BowlingKata.Tests\BowlingKata.Tests.csproj", "{4F2877A9-BE06-4AAD-8A3B-0898D7C2CFB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F2877A9-BE06-4AAD-8A3B-0898D7C2CFB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F2877A9-BE06-4AAD-8A3B-0898D7C2CFB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F2877A9-BE06-4AAD-8A3B-0898D7C2CFB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F2877A9-BE06-4AAD-8A3B-0898D7C2CFB0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BowlingKata/Bowling.cs
+++ b/BowlingKata/Bowling.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata
+{
+    public class Bowling
+    {
+        public int CalculateScore(string rolls)
+        {
+            var rollSeries = new RollSeries(rolls);
+            var score = rollSeries.GetFirstFrameScore();
+
+            if (rollSeries.GetFirstFrameLength() <= rolls.Length)
+                score += CalculateScore(rolls.Substring(rollSeries.GetFirstFrameLength()));
+
+            return score;
+        }
+    }
+}

--- a/BowlingKata/BowlingKata.csproj
+++ b/BowlingKata/BowlingKata.csproj
@@ -40,7 +40,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bowling.cs" />
+    <Compile Include="Frame.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Roll.cs" />
+    <Compile Include="RollSeries.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/BowlingKata/BowlingKata.csproj
+++ b/BowlingKata/BowlingKata.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DEDC4E5D-7C35-4B99-8E8A-89F5B3D40DBD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BowlingKata</RootNamespace>
+    <AssemblyName>BowlingKata</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BowlingKata/Frame.cs
+++ b/BowlingKata/Frame.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata
+{
+    public static class Frame
+    {
+        public static readonly int StandardFrameLength = 2;
+        public static readonly int StrikeFrameLength = 1;
+
+        public static int GetFrameLength(string frame)
+        {
+            return HasStrike(frame) ? StrikeFrameLength : StandardFrameLength;
+        }
+
+        public static bool HasMultiFrameScore(string frame)
+        {
+            return HasSpare(frame) || HasStrike(frame);
+        }
+
+        public static bool HasSpare(string frame)
+        {
+            return frame.Length >= StandardFrameLength && frame[1] == Roll.Spare;
+        }
+
+        public static bool HasStrike(string frame)
+        {
+            return frame.Length >= StrikeFrameLength && frame[0] == Roll.Strike;
+        }
+    }
+}

--- a/BowlingKata/Properties/AssemblyInfo.cs
+++ b/BowlingKata/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BowlingKata")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BowlingKata")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("dedc4e5d-7c35-4b99-8e8a-89f5b3d40dbd")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BowlingKata/Roll.cs
+++ b/BowlingKata/Roll.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata
+{
+    public static class Roll
+    {
+        public static readonly char Gutter = '-';
+        public static readonly char Spare = '/';
+        public static readonly char Strike = 'X';
+        
+        private static readonly Dictionary<char, int> _scoreValues = new Dictionary<char, int>()
+        {
+            { Gutter, 0  },
+            { Spare,  0  },
+            { Strike, 10 }
+        };
+
+        public static int GetScoreOfRoll(char roll)
+        {
+            return _scoreValues.ContainsKey(roll) ? _scoreValues[roll] : int.Parse(roll.ToString());
+        }
+    }
+}

--- a/BowlingKata/RollSeries.cs
+++ b/BowlingKata/RollSeries.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BowlingKata
+{
+    public class RollSeries
+    {
+        private const int ALL_PINS_DOWN_SCORE = 10;
+
+        private readonly string _rolls;
+
+        public RollSeries(string rolls)
+        {
+            _rolls = rolls;
+        }
+
+        public int GetFirstFrameLength()
+        {
+            return Frame.GetFrameLength(_rolls);
+        }
+
+        public int GetFirstFrameScore()
+        {
+            var score = 0;
+
+            if (HasScore())
+                score = Frame.HasMultiFrameScore(_rolls) ? GetMultiFrameScore(_rolls) : GetScoreOfTwoRolls(_rolls);
+
+            return score;
+        }
+
+        private int GetMultiFrameScore(string rolls)
+        {
+            var nextFrame = rolls.Substring(GetFirstFrameLength());
+            return Frame.HasStrike(_rolls) ? GetStrikeScore(nextFrame) : GetSpareScore(nextFrame);
+        }
+
+        private int GetSpareScore(string rolls)
+        {
+            return ALL_PINS_DOWN_SCORE + Roll.GetScoreOfRoll(rolls[0]);
+        }
+
+        private int GetStrikeScore(string rolls)
+        {
+            return ALL_PINS_DOWN_SCORE + GetScoreOfTwoRolls(rolls);
+        }
+
+        private int GetScoreOfTwoRolls(string rolls)
+        {
+            return Frame.HasSpare(rolls) ? ALL_PINS_DOWN_SCORE : 
+                Roll.GetScoreOfRoll(rolls[0]) + Roll.GetScoreOfRoll(rolls[1]);
+        }
+
+        private bool HasScore()
+        {
+            return Frame.HasMultiFrameScore(_rolls) ?
+                   _rolls.Length > Frame.StandardFrameLength :
+                   _rolls.Length > Frame.StrikeFrameLength;
+        }
+    }
+}


### PR DESCRIPTION
`BowlingProperties` is responsible for information related to a roll (ie. score, is strike, frame length, etc). `FrameScoreCalculator` is responsible for calculating the score of a single frame given a string of rolls. `Bowling` is responsible for parsing through the bowling frames in a given string and totaling the score of the frames.